### PR TITLE
Commented out many pin defines as an error occures when building via …

### DIFF
--- a/src/heltec_unofficial.h
+++ b/src/heltec_unofficial.h
@@ -32,18 +32,18 @@
 #define VBAT_CTRL GPIO_NUM_37
 #define VBAT_ADC  GPIO_NUM_1
 // SPI pins
-#define SS        GPIO_NUM_8
-#define MOSI      GPIO_NUM_10
-#define MISO      GPIO_NUM_11
-#define SCK       GPIO_NUM_9
+// #define SS        GPIO_NUM_8
+// #define MOSI      GPIO_NUM_10
+// #define MISO      GPIO_NUM_11
+// #define SCK       GPIO_NUM_9
 // Radio pins
 #define DIO1      GPIO_NUM_14
-#define RST_LoRa  GPIO_NUM_12
-#define BUSY_LoRa GPIO_NUM_13
+// #define RST_LoRa  GPIO_NUM_12
+// #define BUSY_LoRa GPIO_NUM_13
 // Display pins
-#define SDA_OLED  GPIO_NUM_17
-#define SCL_OLED  GPIO_NUM_18
-#define RST_OLED  GPIO_NUM_21
+// #define SDA_OLED  GPIO_NUM_17
+// #define SCL_OLED  GPIO_NUM_18
+// #define RST_OLED  GPIO_NUM_21
 
 #ifdef HELTEC_WIRELESS_STICK_LITE
   #define HELTEC_NO_DISPLAY


### PR DESCRIPTION
…platformIO '.pio/libdeps/heltec_wifi_lora_32_V3/Heltec_ESP32_LoRa_v3/src/heltec_unofficial.h:42:19: error: 'const uint8_t GPIO_NUM_13' redeclared as different kind of symbol.' for all defines being commentted out